### PR TITLE
Adapt to data text value color update changes in ElvUI 13.18+

### DIFF
--- a/ElvUI_MythicPlusDatatext.lua
+++ b/ElvUI_MythicPlusDatatext.lua
@@ -66,7 +66,6 @@ local rgbColor = {
     ["g"] = 0,
     ["b"] = 0
 }
-local lastPanel
 local timewalkingActive
 
 local dungeons = {}
@@ -257,8 +256,6 @@ local function OnEnter(self)
 end
 
 local function OnEvent(self)
-    lastPanel = self
-
     if #dungeons == 0 then
         GetKeystoneDungeonList()
     end
@@ -324,7 +321,7 @@ local function GetClassColor(val)
     return RAID_CLASS_COLORS[class][val]
 end
 
-local function ValueColorUpdate(hex, r, g, b)
+local function ValueColorUpdate(self, hex, r, g, b)
     displayString = join("", "|cffffffff%s|r", hex, "%s|r")
     mpErrorString = join("", hex, "%s|r")
     currentKeyString = join("", hex, "%s|r |cffffffff%s|r")
@@ -333,11 +330,8 @@ local function ValueColorUpdate(hex, r, g, b)
     rgbColor.g = g
     rgbColor.b = b
 
-    if lastPanel ~= nil then
-        OnEvent(lastPanel, "ELVUI_COLOR_UPDATE")
-    end
+    OnEvent(self)
 end
-E.valueColorUpdateFuncs[ValueColorUpdate] = true
 
 P["mplusdt"] = {
     ["labelText"] = "key",
@@ -443,4 +437,4 @@ local function InjectOptions()
 end
 
 EP:RegisterPlugin(..., InjectOptions)
-DT:RegisterDatatext("Mythic+", nil, {"PLAYER_ENTERING_WORLD", "MYTHIC_PLUS_CURRENT_AFFIX_UPDATE", "MYTHIC_PLUS_NEW_WEEKLY_RECORD"}, OnEvent, OnUpdate,  OnClick,  OnEnter, nil, L["Mythic+"])
+DT:RegisterDatatext("Mythic+", nil, {"PLAYER_ENTERING_WORLD", "MYTHIC_PLUS_CURRENT_AFFIX_UPDATE", "MYTHIC_PLUS_NEW_WEEKLY_RECORD"}, OnEvent, OnUpdate,  OnClick,  OnEnter, nil, L["Mythic+"], nil, ValueColorUpdate)


### PR DESCRIPTION
tukui-org/ElvUI@679497d cleaned up the way datatext value colors are updated. This change adopts a similar pattern for this plugin, and avoids a crash/runtime error.

```
2x ElvUI/Core/General/Core.lua:379: attempt to call local 'func' (a boolean value)
[string "@ElvUI/Core/General/Core.lua"]:379: in function `ValueFuncCall'
[string "@ElvUI/Core/General/Core.lua"]:331: in function `UpdateMedia'
[string "@ElvUI/Core/General/Core.lua"]:1949: in function `Initialize'
[string "@ElvUI/Core/init.lua"]:222: in function <ElvUI/Core/init.lua:221>
[string "=[C]"]: ?
[string "@ElvUI_Libraries/Core/Ace3/AceAddon-3.0-13/AceAddon-3.0.lua"]:66: in function <...UI_Libraries/Core/Ace3/AceAddon-3.0/AceAddon-3.0.lua:61>
[string "@ElvUI_Libraries/Core/Ace3/AceAddon-3.0-13/AceAddon-3.0.lua"]:523: in function `EnableAddon'
[string "@ElvUI_Libraries/Core/Ace3/AceAddon-3.0-13/AceAddon-3.0.lua"]:626: in function <...UI_Libraries/Core/Ace3/AceAddon-3.0/AceAddon-3.0.lua:611>
[string "=[C]"]: in function `LoadAddOn'
[string "@FrameXML/UIParent.lua"]:538: in function `UIParentLoadAddOn'
[string "@FrameXML/UIParent.lua"]:743: in function `MajorFactions_LoadUI'
[string "@Blizzard_ExpansionLandingPage/Blizzard_DragonflightLandingPage.lua"]:100: in function `SetUpMajorFactionList'
[string "@Blizzard_ExpansionLandingPage/Blizzard_DragonflightLandingPage.lua"]:93: in function `RefreshMajorFactionList'
[string "@Blizzard_ExpansionLandingPage/Blizzard_DragonflightLandingPage.lua"]:88: in function `RefreshOverlay'
[string "@Blizzard_ExpansionLandingPage/Blizzard_DragonflightLandingPage.lua"]:80: in function <...sionLandingPage/Blizzard_DragonflightLandingPage.lua:76>
[string "=[C]"]: in function `CreateFrame'
[string "@Blizzard_ExpansionLandingPage/Blizzard_DragonflightLandingPage.lua"]:49: in function `CreateOverlay'
[string "@Blizzard_ExpansionLandingPage/Blizzard_ExpansionLandingPage.lua"]:63: in function `RefreshExpansionOverlay'
[string "@Blizzard_ExpansionLandingPage/Blizzard_ExpansionLandingPage.lua"]:35: in function <...pansionLandingPage/Blizzard_ExpansionLandingPage.lua:33>
```

![image](https://user-images.githubusercontent.com/76009320/213285866-1f2f5e98-826a-4060-bc05-5956b41d6117.png)
